### PR TITLE
Perf:  Optimize sign-in, activate and sign-up routes

### DIFF
--- a/src/routes/auth/data.ts
+++ b/src/routes/auth/data.ts
@@ -4,7 +4,10 @@ import { DBTables } from '../../constants/db.ts';
 export async function getLoginInfo(database: D1Database, email: string) {
 	const results = await database
 		.prepare(`
-       SELECT a.password, a.access_level, p.id
+       SELECT
+           a.password as storedPassword,
+           a.access_level as accessLevel,
+           p.id as profileId
        FROM access a
        INNER JOIN
        profile p
@@ -13,7 +16,7 @@ export async function getLoginInfo(database: D1Database, email: string) {
        LIMIT 1
     `)
 		.bind(email)
-		.first<{ password: string, access_level: Access, id: string }>();
+		.first<{ storedPassword: string, accessLevel: Access, profileId: string }>();
 
 	return results;
 }

--- a/src/routes/auth/data.ts
+++ b/src/routes/auth/data.ts
@@ -11,7 +11,7 @@ export async function getLoginInfo(database: D1Database, email: string) {
        FROM access
        INNER JOIN
        profile
-       on profile.id = access.id
+       ON profile.id = access.id
        WHERE profile.email = ? AND profile.activatedAt IS NOT NULL AND profile.deactivatedAt IS NULL
        LIMIT 1
     `)

--- a/src/routes/auth/data.ts
+++ b/src/routes/auth/data.ts
@@ -1,43 +1,21 @@
-import { type AccessSchema, DBTables } from '../../constants/db.ts';
-import type { Profile } from './validate.ts';
+import type { Access } from 'src/types/data/access.ts';
+import { DBTables } from '../../constants/db.ts';
 
-export async function getProfileIdPassword(database: D1Database, email: string) {
-	const { results } = await database
+export async function getLoginInfo(database: D1Database, email: string) {
+	const results = await database
 		.prepare(`
-            SELECT id, password
-            FROM ${DBTables.ACCESS}
-            WHERE email = ?
-			LIMIT 1
-        `)
+       SELECT a.password, a.access_level, p.id
+       FROM access a
+       INNER JOIN
+       profile p
+       on p.id = a.id
+       WHERE p.email = ? and p.activatedAt IS NOT NULL and p.deactivatedAt IS NULL
+       LIMIT 1
+    `)
 		.bind(email)
-		.run<AccessSchema>();
+		.first<{ password: string, access_level: Access, id: string }>();
 
-	return { id: results[0]?.id, password: results[0]?.password };
-}
-
-export async function checkProfile(database: D1Database, profileId: string) {
-	const { results } = await database
-		.prepare(`
-			SELECT id
-			FROM ${DBTables.PROFILE}
-			WHERE id = ?
-			AND activatedAt IS NOT NULL
-			AND deactivatedAt IS NULL
-			LIMIT 1
-		`)
-		.bind(profileId)
-		.run<Profile>();
-
-	return Boolean(results.length);
-}
-
-export async function getAccessLevel(database: D1Database, profileId: string) {
-	const { results } = await database
-		.prepare(`SELECT access_level FROM ${DBTables.ACCESS} WHERE id = ? LIMIT 1`)
-		.bind(profileId)
-		.run<AccessSchema>();
-
-	return results[0]?.access_level;
+	return results;
 }
 
 export async function checkEmail(database: D1Database, email: string) {

--- a/src/routes/auth/data.ts
+++ b/src/routes/auth/data.ts
@@ -5,14 +5,14 @@ export async function getLoginInfo(database: D1Database, email: string) {
 	const results = await database
 		.prepare(`
        SELECT
-           a.password as storedPassword,
-           a.access_level as accessLevel,
-           p.id as profileId
-       FROM access a
+           access.password as storedPassword,
+           access.access_level as accessLevel,
+           profile.id as profileId
+       FROM access
        INNER JOIN
-       profile p
-       on p.id = a.id
-       WHERE p.email = ? and p.activatedAt IS NOT NULL and p.deactivatedAt IS NULL
+       profile
+       on profile.id = access.id
+       WHERE profile.email = ? AND profile.activatedAt IS NOT NULL AND profile.deactivatedAt IS NULL
        LIMIT 1
     `)
 		.bind(email)

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -110,9 +110,9 @@ authRoutes.post('/sign-in', async (context: Context<EnvironmentBindings>) => {
 	}
 
 	const {
-		password: storedPassword,
-		access_level: accessLevel,
-		id: profileId
+		storedPassword,
+		accessLevel,
+		profileId
 	} = results;
 
 	if (!storedPassword) {

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -7,7 +7,7 @@ import { hashPassword, validatePassword } from '../../utils/password-hashing.ts'
 import { StatusCodes, type StatusResponse } from '../../utils/responses.ts';
 import { insertProfile } from '../profile/data.ts';
 import { type CreateProfileRequestBody, CreateProfileSchema } from '../profile/validation.ts';
-import { activateProfile, checkEmail, checkProfile, getAccessLevel, getProfileIdPassword } from './data.ts';
+import { activateProfile, checkEmail, getLoginInfo } from './data.ts';
 import { type SignInData, SignInSchema } from './validate.ts';
 
 export const authRoutes = new Hono();
@@ -102,24 +102,30 @@ authRoutes.post('/sign-in', async (context: Context<EnvironmentBindings>) => {
 		throw error;
 	}
 
-	const { id: profileId, password: storedPassword } = await getProfileIdPassword(context.env.database, parsedBody.email);
-	if (!profileId || !storedPassword) {
-		return context.json<StatusResponse>({ message: 'Invalid email' }, StatusCodes.UNAUTHORIZED);
+	const results = await getLoginInfo(context.env.database, parsedBody.email);
+
+	const genericSignInError = 'Either your email is invalid, not activated or deactivated';
+	if (!results) {
+		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
 	}
 
-	const isProfileValid = await checkProfile(context.env.database, profileId);
-	if (!isProfileValid) {
-		return context.json<StatusResponse>({ message: 'Invalid profile id or Account not activated' }, StatusCodes.UNAUTHORIZED);
+	const {
+		password: storedPassword,
+		access_level: accessLevel,
+		id: profileId
+	} = results;
+
+	if (!storedPassword) {
+		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
 	}
 
-	const accessLevel = await getAccessLevel(context.env.database, profileId);
 	if (!accessLevel) {
-		return context.json<StatusResponse>({ message: 'Access not found' }, StatusCodes.NOT_FOUND);
+		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
 	}
 
 	const isValid = await validatePassword(parsedBody.password, storedPassword);
 	if (!isValid) {
-		return context.json<StatusResponse>({ message: 'Invalid email or password' }, StatusCodes.UNAUTHORIZED);
+		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
 	}
 
 	const sessionToken = crypto.randomUUID();

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -104,7 +104,7 @@ authRoutes.post('/sign-in', async (context: Context<EnvironmentBindings>) => {
 
 	const results = await getLoginInfo(context.env.database, parsedBody.email);
 
-	const genericSignInError = 'Either your email is invalid, not activated or deactivated';
+	const genericSignInError = 'Either your email/password combination is invalid, or your account is not active';
 	if (!results) {
 		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
 	}

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -119,10 +119,6 @@ authRoutes.post('/sign-in', async (context: Context<EnvironmentBindings>) => {
 		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
 	}
 
-	if (!accessLevel) {
-		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);
-	}
-
 	const isValid = await validatePassword(parsedBody.password, storedPassword);
 	if (!isValid) {
 		return context.json<StatusResponse>({ message: genericSignInError }, StatusCodes.UNAUTHORIZED);


### PR DESCRIPTION
## Summary
- combine login sql queries into one join
- update sign-in route to also return generic error messages (can revert if not ok)
- allow user to log in even if no access_level 

## Tests
- verified sign-in route works as expected

## Additional information
- On further inspection I couldn't find a way to optimize the `/activate` route since there is 1 read (`checkEmail`) and 1 write (`activateProfile`)
- Also, I couldn't find a way to further optimize the `/sign-up` route since there is 1 read (`checkEmail`) and 1 batched update (`insertProfile`) 

Resolves https://github.com/torontojs/communityhub-be/issues/95
