### PR TITLE
Fix: auth token should not be sent in response body

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -136,5 +136,5 @@ authRoutes.post('/sign-in', async (context: Context<EnvironmentBindings>) => {
 
 	context.header('Set-Cookie', `auth_token=${sessionToken}; HttpOnly; Secure; SameSite=Strict; Expires=${tokenExpiryISO}; Path=/;`);
 
-	return context.json(sessionToken);
+	return context.json({ message: 'Successfully signed in' });
 });


### PR DESCRIPTION
## Summary

auth token should not be sent in the response body as it is more likely to be intercepted. The token is already being sent as an http only secure cookie.