### PR TITLE
Refactor: move auth middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { Context } from 'hono';
 import { cors } from 'hono/cors';
 import packageJson from '../package.json';
-import { authMiddleware } from './middleware/auth.ts';
 import { authRoutes } from './routes/auth/index.ts';
 import { protectedProfileRoutes, publicProfileRoutes } from './routes/profile/index.ts';
 import { privateRolesRoutes, publicRoleRoutes } from './routes/role/index.ts';
@@ -55,18 +54,16 @@ app.doc('/open-api.json', {
 	}
 });
 
-// Public routes
-app.route('/auth', authRoutes);
-app.route('/roles', publicRoleRoutes);
 // Handle static assets using Cloudflare Workers
 app.get('/assets/*', async (context: Context<EnvironmentBindings>) => context.env.ASSETS.fetch(context.req.raw));
 
 // Public routes
+app.route('/auth', authRoutes);
+app.route('/roles', publicRoleRoutes);
 app.route('/profiles', publicProfileRoutes);
 app.route('/teams', publicTeamRoutes);
 
-// Protected routes (after auth middleware)
-app.use('/*', authMiddleware);
+// Private routes
 app.route('/profiles', protectedProfileRoutes);
 app.route('/teams', protectedTeamRoutes);
 app.route('/roles', privateRolesRoutes);

--- a/src/routes/profile/index.ts
+++ b/src/routes/profile/index.ts
@@ -129,7 +129,7 @@ protectedProfileRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authMiddleware, authMiddleware, authorizeOrganizer] as const
+		middleware: [authMiddleware, authorizeOrganizer] as const
 	}),
 	async (context) => {
 		const body = context.req.valid('json');

--- a/src/routes/profile/index.ts
+++ b/src/routes/profile/index.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+import { authMiddleware } from 'src/middleware/auth.ts';
 import { z } from 'zod';
 import { DBTables } from '../../constants/db.ts';
 import { canModifyProfile } from '../../middleware/canModifyProfile.ts';
@@ -128,7 +129,7 @@ protectedProfileRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeOrganizer] as const
+		middleware: [authMiddleware, authMiddleware, authorizeOrganizer] as const
 	}),
 	async (context) => {
 		const body = context.req.valid('json');
@@ -176,7 +177,7 @@ protectedProfileRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeVolunteer, canModifyProfile] as const
+		middleware: [authMiddleware, authorizeVolunteer, canModifyProfile] as const
 	}),
 	async (context) => {
 		const { id } = context.req.valid('param');
@@ -224,7 +225,7 @@ protectedProfileRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeAdmin] as const
+		middleware: [authMiddleware, authorizeAdmin] as const
 	}),
 	async (context) => {
 		const { id } = context.req.valid('param');

--- a/src/routes/role/index.ts
+++ b/src/routes/role/index.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+import { authMiddleware } from 'src/middleware/auth.ts';
 import { z } from 'zod';
 import { DBTables } from '../../constants/db.ts';
 import { authorizeOrganizer } from '../../middleware/createMiddleware.ts';
@@ -130,7 +131,7 @@ privateRolesRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeOrganizer] as const
+		middleware: [authMiddleware, authorizeOrganizer] as const
 	}),
 	async (context) => {
 		const body = context.req.valid('json');
@@ -171,7 +172,7 @@ privateRolesRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeOrganizer] as const
+		middleware: [authMiddleware, authorizeOrganizer] as const
 	}),
 	async (context) => {
 		const { id } = context.req.valid('param');
@@ -217,7 +218,7 @@ privateRolesRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeOrganizer] as const
+		middleware: [authMiddleware, authorizeOrganizer] as const
 	}),
 	async (context) => {
 		const { id } = context.req.valid('param');

--- a/src/routes/team/index.ts
+++ b/src/routes/team/index.ts
@@ -78,7 +78,7 @@ publicTeamRoutes.openapi(
 				content: { 'application/json': { schema: generatePaginatedResponseSchema(z.array(TeamSchema)) } }
 			}
 		},
-		middleware: [authMiddleware, authorizeVolunteer] as const
+		middleware: [authorizeVolunteer] as const
 	}),
 	async (context) => {
 		const teams = await getAllTeams(context.env.database);

--- a/src/routes/team/index.ts
+++ b/src/routes/team/index.ts
@@ -77,8 +77,7 @@ publicTeamRoutes.openapi(
 				description: 'Successful response',
 				content: { 'application/json': { schema: generatePaginatedResponseSchema(z.array(TeamSchema)) } }
 			}
-		},
-		middleware: [authorizeVolunteer] as const
+		}
 	}),
 	async (context) => {
 		const teams = await getAllTeams(context.env.database);

--- a/src/routes/team/index.ts
+++ b/src/routes/team/index.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+import { authMiddleware } from 'src/middleware/auth.ts';
 import { z } from 'zod';
 import { DBTables } from '../../constants/db.ts';
 import { authorizeAdmin, authorizeOrganizer, authorizeVolunteer } from '../../middleware/createMiddleware.ts';
@@ -77,7 +78,7 @@ publicTeamRoutes.openapi(
 				content: { 'application/json': { schema: generatePaginatedResponseSchema(z.array(TeamSchema)) } }
 			}
 		},
-		middleware: [authorizeVolunteer] as const
+		middleware: [authMiddleware, authorizeVolunteer] as const
 	}),
 	async (context) => {
 		const teams = await getAllTeams(context.env.database);
@@ -134,7 +135,7 @@ protectedTeamRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeAdmin] as const
+		middleware: [authMiddleware, authorizeAdmin] as const
 	}),
 	async (context) => {
 		const { id } = context.req.valid('param');
@@ -177,7 +178,7 @@ protectedTeamRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeAdmin] as const
+		middleware: [authMiddleware, authorizeAdmin] as const
 	}),
 	async (context) => {
 		const body = context.req.valid('json');
@@ -218,7 +219,7 @@ protectedTeamRoutes.openapi(
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			}
 		},
-		middleware: [authorizeOrganizer] as const
+		middleware: [authMiddleware, authorizeOrganizer] as const
 	}),
 	async (context) => {
 		const { id } = context.req.valid('param');

--- a/src/routes/team/index.ts
+++ b/src/routes/team/index.ts
@@ -2,7 +2,7 @@ import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 import { authMiddleware } from 'src/middleware/auth.ts';
 import { z } from 'zod';
 import { DBTables } from '../../constants/db.ts';
-import { authorizeAdmin, authorizeOrganizer, authorizeVolunteer } from '../../middleware/createMiddleware.ts';
+import { authorizeAdmin, authorizeOrganizer } from '../../middleware/createMiddleware.ts';
 import {
 	type DataResponse,
 	generateDataResponeSchema,


### PR DESCRIPTION
## Summary
Refactor auth middleware

## Tests
Run route APIs to check if auth middleware is still running

## Additional Info
While doing the refactor, I noticed the `GET` `/teams` route was listed semantically as a public route but there was a `authorizeVolunteer` middleware check (which also checks for session) so it was acting like a private route. For now I've made it public but I can switch that around

Resolves https://github.com/torontojs/communityhub-be/issues/96