### PR TITLE
Fix: activate route uses query params

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -105,7 +105,7 @@ publicAuthRoutes.openapi(
 		description: 'Received activation email and clicked on activation link',
 		tags: ['Activate'],
 		request: {
-			params: ActivateSchema
+			query: ActivateSchema
 		},
 		responses: {
 			[StatusCodes.BAD_REQUEST]: {
@@ -131,7 +131,7 @@ publicAuthRoutes.openapi(
 		}
 	}),
 	async (context) => {
-		const { token } = context.req.valid('param');
+		const { token } = context.req.valid('query');
 		if (!token) {
 			return context.json({ message: 'Invalid or missing token' }, StatusCodes.BAD_REQUEST);
 		}


### PR DESCRIPTION
## Summary

Activate route was taking `token` as a query param before (if we want to keep existing behavior)