### PR TITLE
Fix: do not allow sign-in if user session exists

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -184,9 +184,9 @@ publicAuthRoutes.openapi(
 		}
 	}),
 	async (context) => {
-		const session = await getSession(context);
+		const existingSession = await getSession(context);
 
-		if (!session) {
+		if (existingSession) {
 			return context.json({ message: 'You are already signed in' } satisfies StatusResponse, StatusCodes.BAD_REQUEST);
 		}
 
@@ -225,19 +225,13 @@ publicAuthRoutes.openapi(
 			return context.json(genericSignInResponse satisfies StatusResponse, StatusCodes.UNAUTHORIZED);
 		}
 
-		const sessionToken = crypto.randomUUID();
-		const hoursOffset = 24;
-		const tokenExpiryISO = addHours(new Date(), hoursOffset).toISOString();
-		const sessionDataObject: SessionData = {
+		const session = {
 			id: profileId,
 			email: parsedBody.email,
-			access: accessLevel,
-			expiry: tokenExpiryISO
+			access: accessLevel
 		};
-		const sessionData = JSON.stringify(sessionDataObject);
-		await context.env.SESSION_TOKENS.put(sessionToken, sessionData);
 
-		await createSession({ session: sessionDataObject, context });
+		await createSession({ session, context });
 
 		return context.json({ message: 'Sign in successful' } satisfies StatusResponse, StatusCodes.CREATED);
 	}

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -1,13 +1,11 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 import sgMail from '@sendgrid/mail';
-import { addHours } from 'date-fns';
 import { type Context, Hono } from 'hono';
 import { createSession, deleteSession, getSession, SESSION_COOKIE_NAME } from 'src/utils/auth.ts';
 import { getCookie } from 'src/utils/cookie.ts';
 import { generateEmailHtml } from '../../email-templates/confirm-email.ts';
 import { authMiddleware } from '../../middleware/auth.ts';
 import { authorizeVolunteer } from '../../middleware/createMiddleware.ts';
-import type { SessionData } from '../../types/data/session';
 import { type HeartbeatResponse, HeartbeatResponseSchema } from '../../utils/heartbeat.ts';
 import { hashPassword, validatePassword } from '../../utils/password-hashing.ts';
 import { StatusCodes, type StatusResponse, statusResponseFormatter, StatusResponseSchema } from '../../utils/responses.ts';

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -170,7 +170,7 @@ publicAuthRoutes.openapi(
 		},
 		responses: {
 			[StatusCodes.BAD_REQUEST]: {
-				description: 'Invalid JSON format:',
+				description: 'Invalid JSON format or already signed in',
 				content: { 'application/json': { schema: StatusResponseSchema } }
 			},
 			[StatusCodes.UNAUTHORIZED]: {
@@ -184,6 +184,12 @@ publicAuthRoutes.openapi(
 		}
 	}),
 	async (context) => {
+		const session = await getSession(context);
+
+		if (!session) {
+			return context.json({ message: 'You are already signed in' } satisfies StatusResponse, StatusCodes.BAD_REQUEST);
+		}
+
 		let parsedBody: SignInData;
 
 		try {


### PR DESCRIPTION
## Summary

- Don't allow users to sign-in if they already have a session
- Redundant KV store call to create session