### PR TITLE
feat: add get profile/self api endpoint

### DIFF
--- a/src/routes/profile/index.ts
+++ b/src/routes/profile/index.ts
@@ -64,6 +64,42 @@ profileRoutes.openapi(
 profileRoutes.openapi(
 	createRoute({
 		method: 'get',
+		path: '/self',
+		operationId: 'Get profile data',
+		summary: 'Get profile data of logged-in user',
+		description: 'Retrieves the profile data of the currently logged-in user',
+		tags: ['Profile'],
+		responses: {
+			[StatusCodes.NOT_FOUND]: {
+				description: 'Internal error getting profile that should exist',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.UNAUTHORIZED]: {
+				description: 'No cookies found, invalid or missing token, invalid session or session expired. ',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.OKAY]: {
+				description: 'Successful response',
+				content: { 'application/json': { schema: generateDataResponeSchema(ProfileSchema) } }
+			}
+		},
+		middleware: [authMiddleware] as const
+	}),
+	async (context) => {
+		const sessionData = getSession(context);
+		const profile = await getProfileById(context.env.Database, sessionData.id);
+
+		if (!profile || profile.id !== sessionData.id) {
+			return context.json({ message: 'Profile not found' } satisfies StatusResponse, StatusCodes.NOT_FOUND);
+		}
+
+		return context.json({ data: profile, _links: { self: { href: context.req.url } } } satisfies DataResponse<typeof profile>, StatusCodes.OKAY);
+	}
+);
+
+profileRoutes.openapi(
+	createRoute({
+		method: 'get',
 		path: '/{id}',
 		operationId: 'Get profile',
 		summary: 'Get profile by ID',


### PR DESCRIPTION
Add get api endpoint to fetch profile data of the currently logged-in user.

## Summary

Add a GET api endpoint to fetch profile of the currently logged-in user

## Tests

Pending.

## Additional information

uses route `/profiles/self`
